### PR TITLE
feat: integrate yen and add support to ignore file patterns

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pycify
-version = 1.1.1
+version = 1.2.0
 description = Convert your entire Python project to .pyc files.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pycify
-version = 1.1.0
+version = 1.1.1
 description = Convert your entire Python project to .pyc files.
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -25,6 +25,8 @@ classifiers =
 packages = find:
 python_requires = >=3.9
 package_dir = =src
+install_requires =
+    yen>=0.4.2
 
 [options.packages.find]
 where = ./src

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,3 @@
 from setuptools import setup
+
 setup()

--- a/src/pycify/__init__.py
+++ b/src/pycify/__init__.py
@@ -105,7 +105,10 @@ def replace_py_with_pyc(
             continue
 
         filename = file.removesuffix(".py")
-        version_info_minor = python_version.split(".")[1]
+        if python_version is None:
+            version_info_minor = str(sys.version_info.minor)
+        else:
+            version_info_minor = python_version.split(".")[1]
         pycache_filename = f"{filename}.cpython-3{version_info_minor}.pyc"
         pyc_path = os.path.join(pycache_path, pycache_filename)
         if not os.path.exists(pyc_path):

--- a/src/pycify/__init__.py
+++ b/src/pycify/__init__.py
@@ -67,22 +67,14 @@ def _replace_py_with_pyc(
     else:
         # Use `yen` to ensure a portable Python is present on the system
         python_version, yen_python_bin_path = ensure_python(python_version)
-        compile_command = f"{yen_python_bin_path} -m compileall -q -f {folder}"
         try:
             subprocess.run(
-                [compile_command],
-                shell=True,
-                env={
-                    "PATH": os.pathsep.join(
-                        [yen_python_bin_path, os.environ.get("PATH", "")]
-                    )
-                },
-                cwd=folder,
+                [yen_python_bin_path, "-mcompileall", "-q", "-f", folder],
                 check=True,
                 capture_output=True,
             )
         except subprocess.CalledProcessError as exc:
-            print("*** Build Failed:", file=sys.stderr)
+            print("*** Pycify Failed:", file=sys.stderr)
             print("Stdout:\n" + exc.stdout.decode(errors="ignore"), file=sys.stderr)
             print("Stderr:\n" + exc.stdout.decode(errors="ignore"), file=sys.stderr)
             raise

--- a/src/pycify/__init__.py
+++ b/src/pycify/__init__.py
@@ -2,8 +2,19 @@ from __future__ import annotations
 
 import compileall
 import os
+import re
 import shutil
 import sys
+import yen.github
+import subprocess
+
+
+class PythonNotAvailable(Exception):
+    """Raised when the Python version asked for is not available for download."""
+
+    def __init__(self, python_version: str) -> None:
+        super().__init__(python_version)
+        self.python_version = python_version
 
 
 def yellow(string: str, /) -> str:
@@ -11,13 +22,46 @@ def yellow(string: str, /) -> str:
     return f"\033[33m{string}\033[m"
 
 
-def replace_py_with_pyc(folder: str, out_folder: str | None = None) -> list[str]:
+def replace_py_with_pyc(
+    folder: str,
+    out_folder: str | None = None,
+    python_version: str | None = None,
+    ignore_file_patterns: list[str] | None = None,
+    _original_folder: str | None = None,
+) -> list[str]:
     """
     Replaces all .py files with the cached .pyc files from __pycache__.
     If out_folder is provided, doesn't delete any existing Python files, simply
     creates the new `.pyc` files in the new location.
     """
-    compileall.compile_dir(folder, quiet=1, force=True)
+    if ignore_file_patterns is None:
+        ignore_file_patterns = []
+    if _original_folder is None:
+        _original_folder = folder
+    if python_version is None:
+        compileall.compile_dir(folder, quiet=1, force=True)
+    else:
+        # Use `yen` to ensure a portable Python is present on the system
+        python_version, yen_python_bin_path = ensure_python(python_version)
+        compile_command = f"{yen_python_bin_path} -m compileall -q -f {folder}"
+        try:
+            subprocess.run(
+                [compile_command],
+                shell=True,
+                env={
+                    "PATH": os.pathsep.join(
+                        [yen_python_bin_path, os.environ.get("PATH", "")]
+                    )
+                },
+                cwd=folder,
+                check=True,
+                capture_output=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            print("*** Build Failed:", file=sys.stderr)
+            print("Stdout:\n" + exc.stdout.decode(errors="ignore"), file=sys.stderr)
+            print("Stderr:\n" + exc.stdout.decode(errors="ignore"), file=sys.stderr)
+            raise
 
     if out_folder is None:
         out_folder = folder
@@ -28,7 +72,15 @@ def replace_py_with_pyc(folder: str, out_folder: str | None = None) -> list[str]
         subfolder = os.path.join(folder, name)
         out_subfolder = os.path.join(out_folder, name)
         if os.path.isdir(subfolder):
-            created_pyc_files.extend(replace_py_with_pyc(subfolder, out_subfolder))
+            created_pyc_files.extend(
+                replace_py_with_pyc(
+                    subfolder,
+                    out_subfolder,
+                    python_version,
+                    ignore_file_patterns,
+                    _original_folder=_original_folder,
+                )
+            )
 
     pycache_path = os.path.join(folder, "__pycache__")
     if not os.path.isdir(pycache_path):
@@ -45,8 +97,16 @@ def replace_py_with_pyc(folder: str, out_folder: str | None = None) -> list[str]
         if not os.path.isfile(filepath):
             continue
 
+        relative_path_file = os.path.relpath(filepath, _original_folder)
+        if any(
+            re.match(pattern, relative_path_file) for pattern in ignore_file_patterns
+        ):
+            print(f"{yellow('NOTE:')} Ignoring {filepath} as per ignore_file_patterns.")
+            continue
+
         filename = file.removesuffix(".py")
-        pycache_filename = f"{filename}.cpython-3{sys.version_info.minor}.pyc"
+        version_info_minor = python_version.split(".")[1]
+        pycache_filename = f"{filename}.cpython-3{version_info_minor}.pyc"
         pyc_path = os.path.join(pycache_path, pycache_filename)
         if not os.path.exists(pyc_path):
             print(f"{yellow('NOTE:')} {pyc_path} not found, skipping.")
@@ -65,3 +125,14 @@ def replace_py_with_pyc(folder: str, out_folder: str | None = None) -> list[str]
     os.rmdir(pycache_path)
 
     return created_pyc_files
+
+
+def ensure_python(version: str) -> tuple[str, str]:
+    """
+    Checks that the version of Python we want to use is available on the
+    system, and if not, downloads it.
+    """
+    try:
+        return yen.ensure_python(version)
+    except yen.github.NotAvailable:
+        raise PythonNotAvailable(version)

--- a/src/pycify/__init__.py
+++ b/src/pycify/__init__.py
@@ -6,8 +6,9 @@ import os
 import re
 import shutil
 import sys
-import yen.github
 import subprocess
+
+import yen.github
 
 
 class PythonNotAvailable(Exception):

--- a/src/pycify/__main__.py
+++ b/src/pycify/__main__.py
@@ -1,4 +1,5 @@
 """Support executing the CLI by doing `python -m pycify`."""
+
 from pycify.cli import cli
 
 if __name__ == "__main__":

--- a/src/pycify/cli.py
+++ b/src/pycify/cli.py
@@ -10,6 +10,8 @@ from pycify import replace_py_with_pyc
 class PycifyArgs:
     directory: str
     out_dir: str
+    python_version: str
+    ignore_file_patterns: list[str]
 
 
 def cli(argv: list[str] | None = None) -> None:

--- a/src/pycify/cli.py
+++ b/src/pycify/cli.py
@@ -33,7 +33,7 @@ def cli(argv: list[str] | None = None) -> None:
     parser.add_argument(
         "--ignore-file-patterns",
         nargs="+",
-        help="List of file patterns to ignore when compiling.",
+        help="File patterns to ignore, eg. `setup.py` or `src/**/*_example.py`",
         default=[
             "setup.py",
         ],

--- a/src/pycify/cli.py
+++ b/src/pycify/cli.py
@@ -1,4 +1,5 @@
 """CLI interface for pycify."""
+
 from __future__ import annotations
 
 import argparse
@@ -22,5 +23,23 @@ def cli(argv: list[str] | None = None) -> None:
             "Defaults to replacing the existing `.py` files."
         ),
     )
+    parser.add_argument(
+        "--python-version",
+        help="Version of Python to compile your project with.",
+        default=None,
+    )
+    parser.add_argument(
+        "--ignore-file-patterns",
+        nargs="+",
+        help="List of file patterns to ignore when compiling.",
+        default=[
+            "setup.py",
+        ],
+    )
     args = parser.parse_args(argv, namespace=PycifyArgs)
-    replace_py_with_pyc(args.directory, out_folder=args.out_dir)
+    replace_py_with_pyc(
+        args.directory,
+        out_folder=args.out_dir,
+        python_version=args.python_version,
+        ignore_file_patterns=args.ignore_file_patterns,
+    )

--- a/tests/pycify_test.py
+++ b/tests/pycify_test.py
@@ -71,3 +71,32 @@ def test_pycify() -> None:
 
     finally:
         shutil.rmtree(clone_path, ignore_errors=True)
+
+
+def test_ignore_file_patterns() -> None:
+    """Ensure ignore_file_patterns work as expected."""
+    clone_url = "https://github.com/tusharsadhwani/packaged"
+    commit_oid = "e2f1d54"
+    clone_path = os.path.join(os.path.dirname(__file__), "packaged")
+
+    try:
+        subprocess.check_call(["git", "clone", clone_url, clone_path])
+        subprocess.check_call(["git", "checkout", commit_oid], cwd=clone_path)
+
+        pycify.replace_py_with_pyc(
+            clone_path,
+            ignore_file_patterns=["example", "setup.py", "tests/**", "**/__main__.*"],
+        )
+        files = pyc_tree(clone_path)
+        assert files == {
+            "src": {
+                "packaged": {
+                    "config.pyc": {},
+                    "cli.pyc": {},
+                    "__init__.pyc": {},
+                },
+            },
+        }
+
+    finally:
+        shutil.rmtree(clone_path, ignore_errors=True)

--- a/tests/pycify_test.py
+++ b/tests/pycify_test.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import os.path
 import shutil
 import subprocess
+from textwrap import dedent
 import typing
 
 import pycify
+import yen
 
 if typing.TYPE_CHECKING:
     FileTree: typing.TypeAlias = "dict[str, FileTree]"
@@ -73,8 +75,8 @@ def test_pycify() -> None:
         shutil.rmtree(clone_path, ignore_errors=True)
 
 
-def test_ignore_file_patterns() -> None:
-    """Ensure ignore_file_patterns work as expected."""
+def test_ignore_file_patterns_and_python_version() -> None:
+    """Ensure ignore_file_patterns and python_version work as expected."""
     clone_url = "https://github.com/tusharsadhwani/packaged"
     commit_oid = "e2f1d54"
     clone_path = os.path.join(os.path.dirname(__file__), "packaged")
@@ -86,6 +88,7 @@ def test_ignore_file_patterns() -> None:
         pycify.replace_py_with_pyc(
             clone_path,
             ignore_file_patterns=["example", "setup.py", "tests/**", "**/__main__.*"],
+            python_version="3.12",
         )
         files = pyc_tree(clone_path)
         assert files == {
@@ -100,3 +103,36 @@ def test_ignore_file_patterns() -> None:
 
     finally:
         shutil.rmtree(clone_path, ignore_errors=True)
+
+
+def test_python_version() -> None:
+    """Test the Python version you compile with can run the compiled code."""
+    test_folder = os.path.join(os.path.dirname(__file__), "test_folder")
+    os.mkdir(test_folder)
+
+    try:
+        test_filepath = os.path.join(test_folder, "foo.py")
+        compiled_output_path = test_filepath + "c"
+        assert not os.path.exists(compiled_output_path)
+
+        code = dedent(
+            """\
+            import sys
+            print(sys.version_info.minor)
+            """
+        )
+        with open(test_filepath, "w") as file:
+            file.write(code)
+
+        pycify.replace_py_with_pyc(
+            test_folder,
+            ignore_file_patterns=["example", "setup.py", "tests/**", "**/__main__.*"],
+            python_version="3.12",
+        )
+
+        _, python_bin_path = yen.ensure_python("3.12")
+        file_output = subprocess.check_output([python_bin_path, compiled_output_path])
+        assert file_output == b"12\n"
+
+    finally:
+        shutil.rmtree(test_folder)


### PR DESCRIPTION
Hi! I was looking at pycify and packaged, awesome projects!

I have added

- support to ignore certain file patterns, primarily because setup.py kept getting replaced and also to ignore some other python files that need not be replaced
- added yen so that pycify can allow compiling with different versions if a python version is provided (Please check my PR on packaged for a use-case)

Do let me know if anything needs to be changed 🙇 